### PR TITLE
Handling (or checking) possible failure in lease's KeepAlive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ It will perform a periodly keep-alive action before it is cancelled explicitly, 
 could accept a handler of type `std::function<std::exception_ptr>` and the handler will be invoked
 when exception occurs during keeping it alive.
 
+Note that the handler will invoked in a separated thread, not the thread where the `KeepAlive` object
+is constructed.
+
 ```c++
   std::function<void (std::exception_ptr)> handler = [](std::exception_ptr eptr) {
     try {

--- a/etcd/KeepAlive.hpp
+++ b/etcd/KeepAlive.hpp
@@ -1,6 +1,8 @@
 #ifndef __ETCD_KEEPALIVE_HPP__
 #define __ETCD_KEEPALIVE_HPP__
 
+#include <exception>
+#include <functional>
 #include <string>
 
 #include "etcd/Client.hpp"
@@ -22,11 +24,25 @@ namespace etcd
   class KeepAlive
   {
   public:
-    KeepAlive(Client const &client, int ttl, int64_t lease_id=0);
-    KeepAlive(std::string const & address, int ttl, int64_t lease_id=0);
+    KeepAlive(Client const &client,
+              int ttl, int64_t lease_id=0);
+    KeepAlive(std::string const & address,
+              int ttl, int64_t lease_id=0);
     KeepAlive(std::string const & address,
               std::string const & username, std::string const & password,
               int ttl, int64_t lease_id=0);
+
+    KeepAlive(Client const &client,
+              std::function<void (std::exception_ptr)> const &handler,
+              int ttl, int64_t lease_id=0);
+    KeepAlive(std::string const & address,
+              std::function<void (std::exception_ptr)> const &handler,
+              int ttl, int64_t lease_id=0);
+    KeepAlive(std::string const & address,
+              std::string const & username, std::string const & password,
+              std::function<void (std::exception_ptr)> const &handler,
+              int ttl, int64_t lease_id=0);
+
 
     KeepAlive(KeepAlive const &) = delete;
     KeepAlive(KeepAlive &&) = delete;
@@ -35,6 +51,13 @@ namespace etcd
      * Stop the keep alive action.
      */
     void Cancel();
+
+    /**
+     * Check if the keep alive is still valid (invalid when there's an async exception).
+     *
+     * Nothing will happen if valid and an exception will be rethrowed if invalid.
+     */
+    void Check();
 
     ~KeepAlive();
 
@@ -49,6 +72,10 @@ namespace etcd
     std::unique_ptr<EtcdServerStubs, EtcdServerStubsDeleter> stubs;
 
   private:
+    // error handling
+    std::exception_ptr eptr_;
+    std::function<void (std::exception_ptr)> handler_;
+
     int ttl;
     int64_t lease_id;
     bool continue_next;

--- a/tst/LockTest.cpp
+++ b/tst/LockTest.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 
 #include "etcd/Client.hpp"
+#include "etcd/KeepAlive.hpp"
 
 
 TEST_CASE("lock and unlock")
@@ -78,4 +79,88 @@ TEST_CASE("double lock will fail")
   CHECK("unlock" == resp5.action());
   REQUIRE(resp5.is_ok());
   REQUIRE(0 == resp5.error_code());
+}
+
+TEST_CASE("lock using lease")
+{
+  etcd::Client etcd("http://127.0.0.1:2379");
+
+  bool failed = false;
+
+  std::function<void (std::exception_ptr)> handler = [&failed](std::exception_ptr eptr) {
+    try {
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
+    } catch(const std::exception& e) {
+        std::cerr << "Caught exception \"" << e.what() << "\"\n";
+        failed = true;
+    }
+  };
+
+  // with handler
+  {
+    // grant lease and keep it alive
+    int64_t lease_id = etcd.leasegrant(5).get().value().lease();
+    etcd::KeepAlive keepalive(etcd, handler, 3, lease_id);
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    // lock
+    etcd::Response resp1 = etcd.lock("/test/abcd", lease_id).get();
+    CHECK("lock" == resp1.action());
+    REQUIRE(resp1.is_ok());
+    REQUIRE(0 == resp1.error_code());
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    // unlock
+    etcd::Response resp2 = etcd.unlock(resp1.lock_key()).get();
+    CHECK("unlock" == resp2.action());
+    REQUIRE(resp2.is_ok());
+    REQUIRE(0 == resp2.error_code());
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+  }
+
+  // without handler
+  {
+    // grant lease and keep it alive
+    int64_t lease_id = etcd.leasegrant(5).get().value().lease();
+    etcd::KeepAlive keepalive(etcd, 3, lease_id);
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    // lock
+    etcd::Response resp1 = etcd.lock("/test/abcd", lease_id).get();
+    CHECK("lock" == resp1.action());
+    REQUIRE(resp1.is_ok());
+    REQUIRE(0 == resp1.error_code());
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+
+    // unlock
+    etcd::Response resp2 = etcd.unlock(resp1.lock_key()).get();
+    CHECK("unlock" == resp2.action());
+    REQUIRE(resp2.is_ok());
+    REQUIRE(0 == resp2.error_code());
+
+    REQUIRE(!failed);
+    keepalive.Check();  // shouldn't throw
+  }
 }


### PR DESCRIPTION
Resolves #49.