### PR TITLE
Use out_of_range exception on lease expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,8 +540,10 @@ is constructed.
         if (eptr) {
             std::rethrow_exception(eptr);
         }
-    } catch(const std::exception& e) {
-        std::cerr << "Caught exception \"" << e.what() << "\"\n";
+    } catch(const std::runtime_error& e) {
+        std::cerr << "Connection failure \"" << e.what() << "\"\n";
+    } catch(const std::out_of_range& e) {
+        std::cerr << "Lease expiry \"" << e.what() << "\"\n";
     }
   };
   etcd::KeepAlive keepalive(etcd, handler, ttl, lease_id);

--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -158,8 +158,8 @@ void etcd::KeepAlive::refresh()
           throw std::runtime_error("Failed to refresh lease: error code: " + std::to_string(resp.error_code()) +
                                    ", message: " + resp.error_message());
         }
-        if (resp.value().ttl() == -1) {
-          throw std::runtime_error("Failed to refresh lease due to expiration: the new TTL is -1.");
+        if (resp.value().ttl() == 0) {
+          throw std::out_of_range("Failed to refresh lease due to expiration: the new TTL is 0.");
         }
         // trigger the next round;
         this->refresh();


### PR DESCRIPTION
Implement a KeepAliveResponse callback, allows KeepAlive users to
detect expiration of KeepAlives by checking ttl.
Update documentation with instructions.