### PR TITLE
Fixes lock, and the underlying keepalive implmentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Users can also feed their own lease directory for lock:
 
 ```c++
   etcd::Client etcd("http://127.0.0.1:4001");
-  etcd.lock("/test/lock", lease_id);
+  etcd.lock_with_lease("/test/lock", lease_id);
 ```
 
 ### Watching for changes
@@ -508,6 +508,13 @@ The lease can be revoked by
 
 ```c++
   etcd.leaserevoke(resp.value().lease());
+```
+
+A lease can also be attached with a `KeepAlive` object at the creation time,
+
+```c++
+  std::shared_ptr<etcd::KeepAlive> keepalive = etcd.leasekeepalive(60).get();
+  std::cout << "lease id: " << keepalive->Lease();
 ```
 
 The remaining time-to-live of a lease can be inspected by

--- a/etcd/Client.hpp
+++ b/etcd/Client.hpp
@@ -328,6 +328,12 @@ namespace etcd
     pplx::task<Response> leasegrant(int ttl);
 
     /**
+     * Grants a lease.
+     * @param ttl is the time to live of the lease
+     */
+    pplx::task<std::shared_ptr<KeepAlive>> leasekeepalive(int ttl);
+
+    /**
      * Revoke a lease.
      * @param lease_id is the id the lease
      */
@@ -359,7 +365,7 @@ namespace etcd
      * of by the library.
      * @param key is the key to be used to request the lock.
      */
-    pplx::task<Response> lock(std::string const &key, int64_t lease_id);
+    pplx::task<Response> lock_with_lease(std::string const &key, int64_t lease_id);
 
     /**
      * Releases a lock at a key.

--- a/etcd/Response.hpp
+++ b/etcd/Response.hpp
@@ -32,18 +32,40 @@ namespace etcd
     {
       return pplx::task<etcd::Response>([call]()
       {
-        etcd::Response resp;     
-
         call->waitForResponse();
-
         auto v3resp = call->ParseResponse();
-          
+
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::high_resolution_clock::now() - call->startTimepoint());
-        resp = etcd::Response(v3resp, duration);    
-
-        return resp;
+        return etcd::Response(v3resp, duration);
       });
+    }
+
+    template <typename T>
+    static pplx::task<etcd::Response> create(std::function<std::shared_ptr<T>()> callfn)
+    {
+      return pplx::task<etcd::Response>([callfn]()
+      {
+        auto call = callfn();
+
+        call->waitForResponse();
+        auto v3resp = call->ParseResponse();
+
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::high_resolution_clock::now() - call->startTimepoint());
+        return etcd::Response(v3resp, duration);
+      });
+    }
+
+    template <typename T>
+    static etcd::Response create_sync(std::shared_ptr<T> call)
+    {
+      call->waitForResponse();
+      auto v3resp = call->ParseResponse();
+
+      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::high_resolution_clock::now() - call->startTimepoint());
+      return etcd::Response(v3resp, duration);
     }
 
     Response();

--- a/etcd/Watcher.hpp
+++ b/etcd/Watcher.hpp
@@ -1,7 +1,9 @@
 #ifndef __ETCD_WATCHER_HPP__
 #define __ETCD_WATCHER_HPP__
 
+#include <functional>
 #include <string>
+#include <thread>
 
 #include "etcd/Client.hpp"
 #include "etcd/Response.hpp"
@@ -81,7 +83,11 @@ namespace etcd
 
     int index;
     std::function<void(Response)> callback;
-    pplx::task<void> currentTask;
+    std::function<void(bool)> wait_callback;
+
+    // Don't use `pplx::task` to avoid sharing thread pool with other actions on the client
+    // to avoid any potential blocking, which may block the keepalive loop and evict the lease.
+    std::thread task_;
 
     struct EtcdServerStubs;
     struct EtcdServerStubsDeleter {

--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -31,8 +31,10 @@ etcd::KeepAlive::KeepAlive(Client const &client, int ttl, int64_t lease_id):
   params.lease_id = this->lease_id;
   params.lease_stub = stubs->leaseServiceStub.get();
 
+  continue_next.store(true);
+
   stubs->call.reset(new etcdv3::AsyncLeaseKeepAliveAction(params));
-  currentTask = pplx::task<void>([this]() {
+  task_ = std::thread([this]() {
     try {
       // start refresh
       this->refresh();
@@ -67,7 +69,7 @@ etcd::KeepAlive::KeepAlive(Client const &client,
   params.lease_stub = stubs->leaseServiceStub.get();
 
   stubs->call.reset(new etcdv3::AsyncLeaseKeepAliveAction(params));
-  currentTask = pplx::task<void>([this]() {
+  task_ = std::thread([this]() {
     try {
       // start refresh
       this->refresh();
@@ -78,8 +80,8 @@ etcd::KeepAlive::KeepAlive(Client const &client,
       } else {
         eptr_ = std::current_exception();
       }
+      this->Cancel();
     }
-    context.stop();  // clean up
   });
 }
 
@@ -103,23 +105,17 @@ etcd::KeepAlive::~KeepAlive()
 
 void etcd::KeepAlive::Cancel()
 {
-  if (!continue_next) {
+  if (!continue_next.exchange(false)) {
     return;
   }
-  continue_next = false;
-#ifndef NDEBUG
-  {
-    std::ios::fmtflags os_flags (std::cout.flags());
-    std::cout << "Cancel keepalive for " << lease_id
-              << "(" << std::hex << lease_id << ")" << std::endl;
-    std::cout.flags(os_flags);
-  }
-#endif
   stubs->call->CancelKeepAlive();
   if (keepalive_timer_) {
     keepalive_timer_->cancel();
   }
-  currentTask.wait();
+
+  // clean up
+  context.stop();
+  task_.join();
 }
 
 void etcd::KeepAlive::Check() {
@@ -130,29 +126,20 @@ void etcd::KeepAlive::Check() {
 
 void etcd::KeepAlive::refresh()
 {
-  if (!continue_next) {
+  if (!continue_next.load()) {
     return;
   }
   // minimal resolution: 1 second
   int keepalive_ttl = std::max(ttl - 1, 1);
-#ifndef NDEBUG
-  {
-    std::ios::fmtflags os_flags (std::cout.flags());
-    std::cout << "Trigger the next keepalive round with ttl " << keepalive_ttl
-              << " for " << lease_id
-              << "(" << std::hex << lease_id << ")" << std::endl;
-    std::cout.flags(os_flags);
-  }
-#endif
   keepalive_timer_.reset(new boost::asio::steady_timer(
       context, std::chrono::seconds(keepalive_ttl)));
   keepalive_timer_->async_wait([this](const boost::system::error_code& error) {
     if (error) {
 #ifndef NDEBUG
-      std::cerr << "keepalive timer error: " << error << ", " << error.message() << std::endl;
+      std::cerr << "keepalive timer cancelled: " << error << ", " << error.message() << std::endl;
 #endif
     } else {
-      if (this->continue_next) {
+      if (this->continue_next.load()) {
         auto resp = this->stubs->call->Refresh();
         if (!resp.is_ok()) {
           throw std::runtime_error("Failed to refresh lease: error code: " + std::to_string(resp.error_code()) +

--- a/src/Watcher.cpp
+++ b/src/Watcher.cpp
@@ -93,21 +93,26 @@ etcd::Watcher::Watcher(std::string const & address,
 etcd::Watcher::~Watcher()
 {
   stubs->call->CancelWatch();
-  currentTask.wait();
+  if (task_.joinable()) {
+    task_.join();
+  }
 }
 
 bool etcd::Watcher::Wait()
 {
-  currentTask.wait();
+  if (task_.joinable()) {
+    task_.join();
+  }
   return stubs->call->Cancelled();
 }
 
 void etcd::Watcher::Wait(std::function<void(bool)> callback)
 {
-  currentTask.then([this, callback](pplx::task<void> const & resp_task) {
-    resp_task.wait();
-    callback(this->stubs->call->Cancelled());
-  });
+  if (wait_callback == nullptr) {
+    wait_callback = callback;
+  } else {
+    std::cerr << "Failed to set a asynchronous wait callback since it has already been set" << std::endl;
+  }
 }
 
 void etcd::Watcher::Cancel()
@@ -133,8 +138,10 @@ void etcd::Watcher::doWatch(std::string const & key,
 
   stubs->call.reset(new etcdv3::AsyncWatchAction(params));
 
-  currentTask = pplx::task<void>([this, callback]()
-  {  
-    return stubs->call->waitForResponse(callback);
+  task_ = std::thread([this, callback]() {
+    stubs->call->waitForResponse(callback);
+    if (wait_callback != nullptr) {
+      wait_callback(stubs->call->Cancelled());
+    }
   });
 }


### PR DESCRIPTION
The previous implementation is buggy when a lot of locks happen at the same time,
as the cpprestsdk's threadpool use a fixed number of thread for posix platform:

https://github.com/microsoft/cpprestsdk/blob/master/Release/src/pplx/threadpool.cpp#L198

Signed-off-by: Tao He <sighingnow@gmail.com>