### PR TITLE
Fixes lock, and the underlying keepalive implmentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Users can also feed their own lease directory for lock:
 
 ```c++
   etcd::Client etcd("http://127.0.0.1:4001");
-  etcd.lock("/test/lock", lease_id);
+  etcd.lock_with_lease("/test/lock", lease_id);
 ```
 
 ### Watching for changes
@@ -508,6 +508,13 @@ The lease can be revoked by
 
 ```c++
   etcd.leaserevoke(resp.value().lease());
+```
+
+A lease can also be attached with a `KeepAlive` object at the creation time,
+
+```c++
+  std::shared_ptr<etcd::KeepAlive> keepalive = etcd.leasekeepalive(60).get();
+  std::cout << "lease id: " << keepalive->Lease();
 ```
 
 The remaining time-to-live of a lease can be inspected by

--- a/etcd/Client.hpp
+++ b/etcd/Client.hpp
@@ -328,6 +328,12 @@ namespace etcd
     pplx::task<Response> leasegrant(int ttl);
 
     /**
+     * Grants a lease.
+     * @param ttl is the time to live of the lease
+     */
+    pplx::task<std::shared_ptr<KeepAlive>> leasekeepalive(int ttl);
+
+    /**
      * Revoke a lease.
      * @param lease_id is the id the lease
      */
@@ -359,7 +365,7 @@ namespace etcd
      * of by the library.
      * @param key is the key to be used to request the lock.
      */
-    pplx::task<Response> lock(std::string const &key, int64_t lease_id);
+    pplx::task<Response> lock_with_lease(std::string const &key, int64_t lease_id);
 
     /**
      * Releases a lock at a key.

--- a/etcd/Response.hpp
+++ b/etcd/Response.hpp
@@ -32,18 +32,40 @@ namespace etcd
     {
       return pplx::task<etcd::Response>([call]()
       {
-        etcd::Response resp;     
-
         call->waitForResponse();
-
         auto v3resp = call->ParseResponse();
-          
+
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::high_resolution_clock::now() - call->startTimepoint());
-        resp = etcd::Response(v3resp, duration);    
-
-        return resp;
+        return etcd::Response(v3resp, duration);
       });
+    }
+
+    template <typename T>
+    static pplx::task<etcd::Response> create(std::function<std::shared_ptr<T>()> callfn)
+    {
+      return pplx::task<etcd::Response>([callfn]()
+      {
+        auto call = callfn();
+
+        call->waitForResponse();
+        auto v3resp = call->ParseResponse();
+
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::high_resolution_clock::now() - call->startTimepoint());
+        return etcd::Response(v3resp, duration);
+      });
+    }
+
+    template <typename T>
+    static etcd::Response create_sync(std::shared_ptr<T> call)
+    {
+      call->waitForResponse();
+      auto v3resp = call->ParseResponse();
+
+      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::high_resolution_clock::now() - call->startTimepoint());
+      return etcd::Response(v3resp, duration);
     }
 
     Response();

--- a/etcd/Watcher.hpp
+++ b/etcd/Watcher.hpp
@@ -1,7 +1,9 @@
 #ifndef __ETCD_WATCHER_HPP__
 #define __ETCD_WATCHER_HPP__
 
+#include <functional>
 #include <string>
+#include <thread>
 
 #include "etcd/Client.hpp"
 #include "etcd/Response.hpp"
@@ -81,7 +83,11 @@ namespace etcd
 
     int index;
     std::function<void(Response)> callback;
-    pplx::task<void> currentTask;
+    std::function<void(bool)> wait_callback;
+
+    // Don't use `pplx::task` to avoid sharing thread pool with other actions on the client
+    // to avoid any potential blocking, which may block the keepalive loop and evict the lease.
+    std::thread task_;
 
     struct EtcdServerStubs;
     struct EtcdServerStubsDeleter {

--- a/etcd/Watcher.hpp
+++ b/etcd/Watcher.hpp
@@ -1,6 +1,7 @@
 #ifndef __ETCD_WATCHER_HPP__
 #define __ETCD_WATCHER_HPP__
 
+#include <atomic>
 #include <functional>
 #include <string>
 #include <thread>
@@ -98,6 +99,7 @@ namespace etcd
   private:
     int fromIndex;
     bool recursive;
+    std::atomic_bool cancelled;
   };
 }
 

--- a/etcd/v3/AsyncWatchAction.hpp
+++ b/etcd/v3/AsyncWatchAction.hpp
@@ -1,6 +1,7 @@
 #ifndef __ASYNC_WATCHACTION_HPP__
 #define __ASYNC_WATCHACTION_HPP__
 
+#include <atomic>
 #include <mutex>
 
 #include <grpc++/grpc++.h>
@@ -28,7 +29,7 @@ namespace etcdv3
     private:
       WatchResponse reply;
       std::unique_ptr<ClientAsyncReaderWriter<WatchRequest,WatchResponse>> stream;   
-      bool isCancelled;
+      std::atomic_bool isCancelled;
       std::mutex protect_is_cancalled;
   };
 }

--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -31,8 +31,10 @@ etcd::KeepAlive::KeepAlive(Client const &client, int ttl, int64_t lease_id):
   params.lease_id = this->lease_id;
   params.lease_stub = stubs->leaseServiceStub.get();
 
+  continue_next.store(true);
+
   stubs->call.reset(new etcdv3::AsyncLeaseKeepAliveAction(params));
-  currentTask = pplx::task<void>([this]() {
+  task_ = std::thread([this]() {
     try {
       // start refresh
       this->refresh();
@@ -67,7 +69,7 @@ etcd::KeepAlive::KeepAlive(Client const &client,
   params.lease_stub = stubs->leaseServiceStub.get();
 
   stubs->call.reset(new etcdv3::AsyncLeaseKeepAliveAction(params));
-  currentTask = pplx::task<void>([this]() {
+  task_ = std::thread([this]() {
     try {
       // start refresh
       this->refresh();
@@ -78,8 +80,8 @@ etcd::KeepAlive::KeepAlive(Client const &client,
       } else {
         eptr_ = std::current_exception();
       }
+      this->Cancel();
     }
-    context.stop();  // clean up
   });
 }
 
@@ -103,23 +105,17 @@ etcd::KeepAlive::~KeepAlive()
 
 void etcd::KeepAlive::Cancel()
 {
-  if (!continue_next) {
+  if (!continue_next.exchange(false)) {
     return;
   }
-  continue_next = false;
-#ifndef NDEBUG
-  {
-    std::ios::fmtflags os_flags (std::cout.flags());
-    std::cout << "Cancel keepalive for " << lease_id
-              << "(" << std::hex << lease_id << ")" << std::endl;
-    std::cout.flags(os_flags);
-  }
-#endif
   stubs->call->CancelKeepAlive();
   if (keepalive_timer_) {
     keepalive_timer_->cancel();
   }
-  currentTask.wait();
+
+  // clean up
+  context.stop();
+  task_.join();
 }
 
 void etcd::KeepAlive::Check() {
@@ -130,29 +126,20 @@ void etcd::KeepAlive::Check() {
 
 void etcd::KeepAlive::refresh()
 {
-  if (!continue_next) {
+  if (!continue_next.load()) {
     return;
   }
   // minimal resolution: 1 second
   int keepalive_ttl = std::max(ttl - 1, 1);
-#ifndef NDEBUG
-  {
-    std::ios::fmtflags os_flags (std::cout.flags());
-    std::cout << "Trigger the next keepalive round with ttl " << keepalive_ttl
-              << " for " << lease_id
-              << "(" << std::hex << lease_id << ")" << std::endl;
-    std::cout.flags(os_flags);
-  }
-#endif
   keepalive_timer_.reset(new boost::asio::steady_timer(
       context, std::chrono::seconds(keepalive_ttl)));
   keepalive_timer_->async_wait([this](const boost::system::error_code& error) {
     if (error) {
 #ifndef NDEBUG
-      std::cerr << "keepalive timer error: " << error << ", " << error.message() << std::endl;
+      std::cerr << "keepalive timer cancelled: " << error << ", " << error.message() << std::endl;
 #endif
     } else {
-      if (this->continue_next) {
+      if (this->continue_next.load()) {
         auto resp = this->stubs->call->Refresh();
         if (!resp.is_ok()) {
           throw std::runtime_error("Failed to refresh lease: error code: " + std::to_string(resp.error_code()) +

--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -115,7 +115,9 @@ void etcd::KeepAlive::Cancel()
 
   // clean up
   context.stop();
-  task_.join();
+  if (task_.joinable()) {
+    task_.join();
+  }
 }
 
 void etcd::KeepAlive::Check() {

--- a/src/Watcher.cpp
+++ b/src/Watcher.cpp
@@ -92,16 +92,15 @@ etcd::Watcher::Watcher(std::string const & address,
 
 etcd::Watcher::~Watcher()
 {
-  stubs->call->CancelWatch();
-  if (task_.joinable()) {
-    task_.join();
-  }
+  this->Cancel();
 }
 
 bool etcd::Watcher::Wait()
 {
-  if (task_.joinable()) {
-    task_.join();
+  if (cancelled.exchange(true)) {
+    if (task_.joinable()) {
+      task_.join();
+    }
   }
   return stubs->call->Cancelled();
 }
@@ -144,4 +143,5 @@ void etcd::Watcher::doWatch(std::string const & key,
       wait_callback(stubs->call->Cancelled());
     }
   });
+  cancelled.store(false);
 }

--- a/src/Watcher.cpp
+++ b/src/Watcher.cpp
@@ -97,7 +97,7 @@ etcd::Watcher::~Watcher()
 
 bool etcd::Watcher::Wait()
 {
-  if (cancelled.exchange(true)) {
+  if (!cancelled.exchange(true)) {
     if (task_.joinable()) {
       task_.join();
     }

--- a/src/Watcher.cpp
+++ b/src/Watcher.cpp
@@ -93,21 +93,26 @@ etcd::Watcher::Watcher(std::string const & address,
 etcd::Watcher::~Watcher()
 {
   stubs->call->CancelWatch();
-  currentTask.wait();
+  if (task_.joinable()) {
+    task_.join();
+  }
 }
 
 bool etcd::Watcher::Wait()
 {
-  currentTask.wait();
+  if (task_.joinable()) {
+    task_.join();
+  }
   return stubs->call->Cancelled();
 }
 
 void etcd::Watcher::Wait(std::function<void(bool)> callback)
 {
-  currentTask.then([this, callback](pplx::task<void> const & resp_task) {
-    resp_task.wait();
-    callback(this->stubs->call->Cancelled());
-  });
+  if (wait_callback == nullptr) {
+    wait_callback = callback;
+  } else {
+    std::cerr << "Failed to set a asynchronous wait callback since it has already been set" << std::endl;
+  }
 }
 
 void etcd::Watcher::Cancel()
@@ -133,8 +138,10 @@ void etcd::Watcher::doWatch(std::string const & key,
 
   stubs->call.reset(new etcdv3::AsyncWatchAction(params));
 
-  currentTask = pplx::task<void>([this, callback]()
-  {  
-    return stubs->call->waitForResponse(callback);
+  task_ = std::thread([this, callback]() {
+    stubs->call->waitForResponse(callback);
+    if (wait_callback != nullptr) {
+      wait_callback(stubs->call->Cancelled());
+    }
   });
 }

--- a/src/v3/AsyncWatchAction.cpp
+++ b/src/v3/AsyncWatchAction.cpp
@@ -9,7 +9,7 @@ using etcdserverpb::WatchCreateRequest;
 etcdv3::AsyncWatchAction::AsyncWatchAction(etcdv3::ActionParameters param)
   : etcdv3::Action(param) 
 {
-  isCancelled = false;
+  isCancelled.store(false);
   stream = parameters.watch_stub->AsyncWatch(&context,&cq_,(void*)"create");
 
   WatchRequest watch_req;
@@ -61,14 +61,14 @@ void etcdv3::AsyncWatchAction::waitForResponse()
       break;
     }
     if(got_tag == (void*)"writes done") {
-      isCancelled = true;
+      isCancelled.store(true);
       cq_.Shutdown();
       break;
     }
     if(got_tag == (void*)this) // read tag
     {
       if (reply.canceled()) {
-        isCancelled = true;
+        isCancelled.store(true);
         cq_.Shutdown();
       }
       else if ((reply.created() && reply.header().revision() < parameters.revision) ||
@@ -77,7 +77,7 @@ void etcdv3::AsyncWatchAction::waitForResponse()
         //
         // 1. watch for a future revision, return immediately with empty events set
         // 2. receive any effective events.
-        isCancelled = true;
+        isCancelled.store(true);
         stream->WritesDone((void*)"writes done");
         grpc::Status status;
         stream->Finish(&status, (void *)this);
@@ -100,9 +100,7 @@ void etcdv3::AsyncWatchAction::waitForResponse()
 void etcdv3::AsyncWatchAction::CancelWatch()
 {
   std::lock_guard<std::mutex> scope_lock(this->protect_is_cancalled);
-  if(isCancelled == false)
-  {
-    isCancelled = true;
+  if (!isCancelled.exchange(true)) {
     stream->WritesDone((void*)"writes done");
     grpc::Status status;
     stream->Finish(&status, (void *)this);
@@ -111,7 +109,7 @@ void etcdv3::AsyncWatchAction::CancelWatch()
 }
 
 bool etcdv3::AsyncWatchAction::Cancelled() const {
-  return isCancelled;
+  return isCancelled.load();
 }
 
 void etcdv3::AsyncWatchAction::waitForResponse(std::function<void(etcd::Response)> callback) 
@@ -127,14 +125,14 @@ void etcdv3::AsyncWatchAction::waitForResponse(std::function<void(etcd::Response
     }
     if(got_tag == (void*)"writes done")
     {
-      isCancelled = true;
+      isCancelled.store(true);
       cq_.Shutdown();
       break;
     }
     else if(got_tag == (void*)this) // read tag
     {
       if (reply.canceled()) {
-        isCancelled = true;
+        isCancelled.store(true);
         cq_.Shutdown();
         if (reply.compact_revision() != 0) {
           callback(etcd::Response(grpc::StatusCode::OUT_OF_RANGE /* error code */,
@@ -159,7 +157,6 @@ void etcdv3::AsyncWatchAction::waitForResponse(std::function<void(etcd::Response
 
 etcdv3::AsyncWatchResponse etcdv3::AsyncWatchAction::ParseResponse()
 {
-
   AsyncWatchResponse watch_resp;
   if(!status.ok())
   {


### PR DESCRIPTION
The previous implementation is buggy when a lot of locks happen at the same time,
as the cpprestsdk's threadpool use a fixed number of thread for posix platform:

https://github.com/microsoft/cpprestsdk/blob/master/Release/src/pplx/threadpool.cpp#L198

Signed-off-by: Tao He <sighingnow@gmail.com>