### PR TITLE
Removing memory-leak, fixes #83.

### DIFF
--- a/src/v3/Action.cpp
+++ b/src/v3/Action.cpp
@@ -40,16 +40,14 @@ const std::chrono::high_resolution_clock::time_point etcdv3::Action::startTimepo
 }
 
 std::string etcdv3::detail::string_plus_one(std::string const &value) {
-  // referred from the Go implementation in etcd.
-  char *s = static_cast<char *>(calloc(value.size() + 1, sizeof(char)));
-  std::memcpy(s, value.c_str(), value.size());
-  for (int i = value.size() - 1; i >= 0; --i) {
-    if (static_cast<unsigned char>(s[i]) < 0xff) {
+  // Referred from the Go implementation in etcd.
+  for (int32_t i = value.size() - 1; i >= 0; --i) {
+    if (static_cast<unsigned char>(value[i]) < 0xff) {
+      std::string s = value.substr(0, i + 1);
       s[i] = s[i] + 1;
-      std::string ret = std::string(s, i + 1);
-      free(s);
-      return ret;
+      return s;
     }
   }
+
   return {etcdv3::NUL};
 }


### PR DESCRIPTION
Also, another comment, if "\0xFF\0xFF" is passed in "string_plus_one" parameter, nul is returned, is this really what was expected?