### PR TITLE
Allow changing Transaction key

### DIFF
--- a/etcd/v3/Transaction.hpp
+++ b/etcd/v3/Transaction.hpp
@@ -30,6 +30,9 @@ public:
 	Transaction();
 	Transaction(std::string const&);
 	virtual ~Transaction();
+
+	void set_key(std::string const& comp_key);
+
 	void init_compare(CompareResult, CompareTarget);
 	void init_compare(std::string const &old_value, CompareResult, CompareTarget);
 	void init_compare(int old_value, CompareResult, CompareTarget);

--- a/src/v3/Transaction.cpp
+++ b/src/v3/Transaction.cpp
@@ -32,6 +32,10 @@ etcdv3::Transaction::Transaction(const std::string& key) : key(key) {
 	txn_request.reset(new etcdserverpb::TxnRequest{});
 }
 
+void etcdv3::set_key(std::string const& comp_key) {
+	key = comp_key;
+}
+
 void etcdv3::Transaction::init_compare(CompareResult result, CompareTarget target){
 	Compare* compare = txn_request->add_compare();
 	compare->set_result(detail::to_compare_result(result));


### PR DESCRIPTION
Fix: #92 

The goal is to be able to do comparison operations on different keys within the same transaction. Currently this is not possible via the API.

I wanted to call this `set_compare_key` but it looks like it's also used in `setup_compare_and_swap_sequence`.

Alternatively we could add new overloads to `init_compare` and `setup_compare_and_swap_sequence` which accept keys as a parameter. I think that would be a more robust API, but I didn't want to add too many changes unless you all would prefer it.

Please let me know the preferred route and I can update accordingly. Thanks!



