### PR TITLE
Revisit the watcher's reconnect functionality. 

### DIFF
--- a/etcd/Watcher.hpp
+++ b/etcd/Watcher.hpp
@@ -70,17 +70,13 @@ namespace etcd
      * An async wait, the callback will be called when the task has been stopped.
      *
      * The callback parameter would be true if the watch is been normally cancalled.
-     * If callback returns true, will reactivate the watcher and continue receiving 
-     * watch events, otherwise the watcher ends (default behaviour).
      */
-    void Wait(std::function<bool(bool)> callback);
+    void Wait(std::function<void(bool)> callback);
 
     /**
      * Stop the watching action.
-     * 
-     * Returns true if the watcher has been cancelled, otherwise false.
      */
-    bool Cancel();
+    void Cancel();
 
     ~Watcher();
 
@@ -92,7 +88,7 @@ namespace etcd
 
     int index;
     std::function<void(Response)> callback;
-    std::function<bool(bool)> wait_callback;
+    std::function<void(bool)> wait_callback;
 
     // Don't use `pplx::task` to avoid sharing thread pool with other actions on the client
     // to avoid any potential blocking, which may block the keepalive loop and evict the lease.

--- a/etcd/Watcher.hpp
+++ b/etcd/Watcher.hpp
@@ -76,7 +76,12 @@ namespace etcd
     /**
      * Stop the watching action.
      */
-    void Cancel();
+    bool Cancel();
+
+    /**
+     * Whether the watcher has been cancelled.
+     */
+    bool Cancelled() const;
 
     ~Watcher();
 

--- a/etcd/v3/AsyncWatchAction.hpp
+++ b/etcd/v3/AsyncWatchAction.hpp
@@ -29,7 +29,6 @@ namespace etcdv3
       WatchResponse reply;
       std::unique_ptr<ClientAsyncReaderWriter<WatchRequest,WatchResponse>> stream;   
       std::atomic_bool isCancelled;
-      std::mutex protect_is_cancalled;
   };
 }
 

--- a/src/v3/AsyncWatchAction.cpp
+++ b/src/v3/AsyncWatchAction.cpp
@@ -108,7 +108,6 @@ void etcdv3::AsyncWatchAction::waitForResponse()
 
 void etcdv3::AsyncWatchAction::CancelWatch()
 {
-  std::lock_guard<std::mutex> scope_lock(this->protect_is_cancalled);
   if (!isCancelled.exchange(true)) {
     stream->WritesDone((void*)etcdv3::WATCH_WRITES_DONE);
 

--- a/tst/RewatchTest.cpp
+++ b/tst/RewatchTest.cpp
@@ -1,0 +1,100 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <chrono>
+#include <thread>
+
+#include "etcd/Watcher.hpp"
+#include "etcd/SyncClient.hpp"
+
+static std::string etcd_uri("http://127.0.0.1:2379");
+static int watcher_called = 0;
+
+void print_response(etcd::Response const & resp)
+{
+  ++watcher_called;
+  std::cout << "print response called" << std::endl;
+  if (resp.error_code()) {
+    std::cout << resp.error_code() << ": " << resp.error_message() << std::endl;
+  }
+  else {
+    std::cout << resp.action() << " " << resp.value().as_string() << std::endl;
+    std::cout << "Previous value: " << resp.prev_value().as_string() << std::endl;
+
+    std::cout << "Events size: " << resp.events().size() << std::endl;
+    for (auto const &ev: resp.events()) {
+      std::cout << "Value change in events: " << static_cast<int>(ev.event_type())
+                << ", prev kv = " << ev.prev_kv().key() << " -> " << ev.prev_kv().as_string()
+                << ", kv = " << ev.kv().key() << " -> " << ev.kv().as_string()
+                << std::endl;
+    }
+  }
+}
+
+void wait_for_connection(etcd::Client &client) {
+  // wait until the client connects to etcd server 
+  while (!client.head().get().is_ok()) {
+    sleep(1);
+  }
+}
+
+void initialize_watcher(const std::string& endpoints,
+	                      const std::string& prefix,
+	                      std::function<void(etcd::Response)> callback,
+	                      std::shared_ptr<etcd::Watcher>& watcher) {
+	etcd::Client client(endpoints);
+	wait_for_connection(client);
+
+  // Check if the failed one has been cancelled first
+  if (watcher && watcher->Cancelled()) {
+    std::cout << "watcher's reconnect loop been cancelled" << std::endl;
+    return;
+  }
+	watcher.reset(new etcd::Watcher(client, prefix, callback, true));
+
+	// Note that lambda requires `mutable`qualifier.
+	watcher->Wait([endpoints, prefix, callback,
+		  /* By reference for renewing */ &watcher](bool cancelled) mutable {
+    if (cancelled) {
+      std::cout << "watcher's reconnect loop stopped as been cancelled" << std::endl;
+      return;
+    }
+    initialize_watcher(endpoints, prefix, callback, watcher);
+	});
+}
+
+TEST_CASE("watch should can be re-established")
+{
+  const std::string my_prefix = "/test";
+
+  // the watcher initialized in this way will auto re-connect to etcd
+  std::shared_ptr<etcd::Watcher> watcher;
+  initialize_watcher(etcd_uri, my_prefix, print_response, watcher);
+
+  // issue some changes to see if the watcher works
+  for (int round = 0; round < 10; ++round) {
+    try {
+      etcd::Client client(etcd_uri);
+      auto response = client.set(my_prefix + "/foo", "bar-" + std::to_string(round)).get();
+    } catch (...) {
+      // pass
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
+
+  // cancel the worker
+  watcher->Cancel();
+
+  // the watcher has been cancelled and shouldn't work anymore
+  for (int round = 10; round < 20; ++round) {
+    try {
+      etcd::Client client(etcd_uri);
+      auto response = client.set(my_prefix + "/foo", "bar-" + std::to_string(round)).get();
+    } catch (...) {
+      // pass
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
+}

--- a/tst/WatcherTest.cpp
+++ b/tst/WatcherTest.cpp
@@ -17,8 +17,7 @@ void printResponse(etcd::Response const & resp)
   if (resp.error_code()) {
     std::cout << resp.error_code() << ": " << resp.error_message() << std::endl;
   }
-  else
-  {
+  else {
     std::cout << resp.action() << " " << resp.value().as_string() << std::endl;
     std::cout << "Previous value: " << resp.prev_value().as_string() << std::endl;
 


### PR DESCRIPTION
Address https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/issues/73, https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/pull/76, https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/issues/117 and https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/pull/118.

Revoke #118 as well.