### PR TITLE
Enable grpc timeout support in keepalive's refresh.

### DIFF
--- a/etcd/Client.hpp
+++ b/etcd/Client.hpp
@@ -1,6 +1,7 @@
 #ifndef __ETCD_CLIENT_HPP__
 #define __ETCD_CLIENT_HPP__
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -625,8 +626,7 @@ namespace etcd
     /**
      * Get the current timeout value for grpc operations.
      */
-    template <typename Rep = std::micro>
-    std::chrono::duration<Rep> get_grpc_timeout() const {
+    std::chrono::microseconds get_grpc_timeout() const {
        return this->client->get_grpc_timeout();
     }
 

--- a/etcd/KeepAlive.hpp
+++ b/etcd/KeepAlive.hpp
@@ -2,6 +2,7 @@
 #define __ETCD_KEEPALIVE_HPP__
 
 #include <atomic>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <string>
@@ -72,6 +73,21 @@ namespace etcd
      */
     void Check();
 
+    /**
+     * Set a timeout value for grpc operations.
+     */
+    template <typename Rep = std::micro>
+    void set_grpc_timeout(std::chrono::duration<Rep> const &timeout) {
+      this->grpc_timeout = std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+    }
+
+    /**
+     * Get the current timeout value for grpc operations.
+     */
+    std::chrono::microseconds get_grpc_timeout() const {
+      return this->grpc_timeout;
+    }
+
     ~KeepAlive();
 
   protected:
@@ -95,6 +111,10 @@ namespace etcd
     int ttl;
     int64_t lease_id;
     std::atomic_bool continue_next;
+
+    // grpc timeout in `refresh()`
+    mutable std::chrono::microseconds grpc_timeout = std::chrono::microseconds::zero();
+
 #if BOOST_VERSION >= 106600
     boost::asio::io_context context;
 #else

--- a/etcd/SyncClient.hpp
+++ b/etcd/SyncClient.hpp
@@ -724,9 +724,8 @@ namespace etcd
     /**
      * Get the current timeout value for grpc operations.
      */
-    template <typename Rep = std::micro>
-    std::chrono::duration<Rep> get_grpc_timeout() const {
-      return std::chrono::duration_cast<std::chrono::duration<Rep>>(grpc_timeout);
+    std::chrono::microseconds get_grpc_timeout() const {
+      return this->grpc_timeout;
     }
 
   private:

--- a/etcd/v3/AsyncLeaseAction.hpp
+++ b/etcd/v3/AsyncLeaseAction.hpp
@@ -21,6 +21,10 @@ using etcdserverpb::LeaseTimeToLiveResponse;
 using etcdserverpb::LeaseStatus;
 using etcdserverpb::LeaseLeasesResponse;
 
+namespace etcd {
+  class KeepAlive;
+}
+
 namespace etcdv3
 {
   class AsyncLeaseGrantAction : public etcdv3::Action {
@@ -51,12 +55,16 @@ namespace etcdv3
       bool Cancelled() const;
 
     private:
+      etcdv3::ActionParameters& mutable_parameters();
+
       LeaseKeepAliveResponse reply;
       std::unique_ptr<ClientAsyncReaderWriter<LeaseKeepAliveRequest, LeaseKeepAliveResponse>> stream;
 
       LeaseKeepAliveRequest req;
       bool isCancelled;
       std::mutex protect_is_cancelled;
+
+      friend class etcd::KeepAlive;
   };
 
   class AsyncLeaseTimeToLiveAction: public etcdv3::Action {


### PR DESCRIPTION
Resolves #127, and replaces #128.