### PR TITLE
build: as submodule, cancel `add_test()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,11 @@ endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
-enable_testing()
 add_subdirectory(src)
-add_subdirectory(tst)
+if(BUILD_ETCD_TESTS)
+  enable_testing()
+  add_subdirectory(tst)
+endif()
 
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/etcd/Client.hpp
                ${CMAKE_CURRENT_SOURCE_DIR}/etcd/KeepAlive.hpp


### PR DESCRIPTION
if we use `etcd-cpp-apiv3` as submodule, we don't need to test `etcd-cpp-apiv3`.
in `CMakeLists.txt`
```
enable_testing()
add_subdirectory(src)
add_subdirectory(tst)
```
this code force to set `add_test()` and maybe make the project failed to `unit tests`.

Signed-off-by: zhang.han <dalezh@163.com>