### PR TITLE
build: update use_cxx11 to use_cxx14

### DIFF
--- a/.github/workflows/centos-latest.yml
+++ b/.github/workflows/centos-latest.yml
@@ -16,10 +16,6 @@ jobs:
         os: [ubuntu-20.04]
         etcd: [v3.4.13]
     steps:
-      - name: Get time
-        run: |
-          date +'%Y-%m' > snapshot.txt
-
       - name: Install dependencies for Linux
         run: |
           # switch to centos stream

--- a/.github/workflows/centos-latest.yml
+++ b/.github/workflows/centos-latest.yml
@@ -40,15 +40,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Get time
-        run: |
-          date +'%Y-%m' > snapshot.txt
-
       - name: Cache for cccahe
         uses: actions/cache@v3
         with:
           path: /home/runner/.ccache
-          key: ${{ runner.os }}-centos-ccache-${{ hashFiles('**/snapshot.txt') }}
+          key: ${{ runner.os }}-centos-ccache-${{ hashFiles('/CMakeLists.txt') }}
           restore-keys: |
             ${{ runner.os }}-centos-ccache-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,20 +60,20 @@ if(NOT (CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache") AND NOT (CMAKE_C_COMPILER_
     endif(ccache_EXECUTABLE)
 endif()
 
-macro(use_cxx11 target)
+macro(use_cxx14 target)
     if(CMAKE_VERSION VERSION_LESS "3.1")
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            target_compile_options(${target} PRIVATE "-std=gnu++11")
+            target_compile_options(${target} PRIVATE "-std=gnu++14")
         else()
-            target_compile_options(${target} PRIVATE "-std=c++11")
+            target_compile_options(${target} PRIVATE "-std=c++14")
         endif()
     else()
         set_target_properties(${target} PROPERTIES
-            CXX_STANDARD 11
+            CXX_STANDARD 14
             CXX_STANDARD_REQUIRED ON
         )
     endif()
-endmacro(use_cxx11)
+endmacro(use_cxx14)
 
 find_package(Boost REQUIRED COMPONENTS system thread random)
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,16 @@ option(BUILD_SHARED_LIBS "Build etcd-cpp-apiv3 shared libraries" ON)
 option(BUILD_ETCD_TESTS "Build etcd-cpp-apiv3 test cases" OFF)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build etcd-cpp-apiv3 with -fPIC" ON)
 option(ETCD_W_STRICT "Build etcd-cpp-apiv3 with -Werror" ON)
+option(ETCD_CMAKE_CXX_STANDARD "Build etcd-cpp-apiv3 with specified C++ standard, e.g., 11, 14, 17, 20" "")
+
+if(NOT "${ETCD_CMAKE_CXX_STANDARD}")
+    if(NOT "${CMAKE_CXX_STANDARD}")
+        set(ETCD_CMAKE_CXX_STANDARD 11)
+    else()
+        set(ETCD_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+    endif()
+endif()
+message("Building etcd-cpp-apiv3 with C++${ETCD_CMAKE_CXX_STANDARD}")
 
 # reference: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
@@ -60,20 +70,20 @@ if(NOT (CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache") AND NOT (CMAKE_C_COMPILER_
     endif(ccache_EXECUTABLE)
 endif()
 
-macro(use_cxx14 target)
+macro(use_cxx target)
     if(CMAKE_VERSION VERSION_LESS "3.1")
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            target_compile_options(${target} PRIVATE "-std=gnu++14")
+            target_compile_options(${target} PRIVATE "-std=gnu++${ETCD_CMAKE_CXX_STANDARD}")
         else()
-            target_compile_options(${target} PRIVATE "-std=c++14")
+            target_compile_options(${target} PRIVATE "-std=c++${ETCD_CMAKE_CXX_STANDARD}")
         endif()
     else()
         set_target_properties(${target} PROPERTIES
-            CXX_STANDARD 14
+            CXX_STANDARD ${ETCD_CMAKE_CXX_STANDARD}
             CXX_STANDARD_REQUIRED ON
         )
     endif()
-endmacro(use_cxx14)
+endmacro(use_cxx)
 
 find_package(Boost REQUIRED COMPONENTS system thread random)
 if(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,13 +18,13 @@ file(GLOB_RECURSE CPP_CLIENT_CORE_SRC
 )
 
 add_library(etcd-cpp-api-core-objects OBJECT ${CPP_CLIENT_CORE_SRC} ${PROTOBUF_GENERATES})
-use_cxx14(etcd-cpp-api-core-objects)
+use_cxx(etcd-cpp-api-core-objects)
 add_dependencies(etcd-cpp-api-core-objects protobuf_generates)
 include_generated_protobuf_files(etcd-cpp-api-core-objects)
 
 # add the core library, includes the sycnhronous client only
 add_library(etcd-cpp-api-core $<TARGET_OBJECTS:etcd-cpp-api-core-objects>)
-use_cxx14(etcd-cpp-api-core)
+use_cxx(etcd-cpp-api-core)
 target_link_libraries(etcd-cpp-api-core PUBLIC
                       ${Boost_LIBRARIES}
                       ${PROTOBUF_LIBRARIES}
@@ -36,7 +36,7 @@ include_generated_protobuf_files(etcd-cpp-api-core)
 # add the client with asynchronus client
 add_library(etcd-cpp-api $<TARGET_OBJECTS:etcd-cpp-api-core-objects>
                          "${CMAKE_CURRENT_SOURCE_DIR}/Client.cpp")
-use_cxx14(etcd-cpp-api)
+use_cxx(etcd-cpp-api)
 target_link_libraries(etcd-cpp-api PUBLIC
                       ${Boost_LIBRARIES}
                       ${CPPREST_LIB}  # n.b.: the asynchronous client requires pplx in cpprestsdk

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,13 +18,13 @@ file(GLOB_RECURSE CPP_CLIENT_CORE_SRC
 )
 
 add_library(etcd-cpp-api-core-objects OBJECT ${CPP_CLIENT_CORE_SRC} ${PROTOBUF_GENERATES})
-use_cxx11(etcd-cpp-api-core-objects)
+use_cxx14(etcd-cpp-api-core-objects)
 add_dependencies(etcd-cpp-api-core-objects protobuf_generates)
 include_generated_protobuf_files(etcd-cpp-api-core-objects)
 
 # add the core library, includes the sycnhronous client only
 add_library(etcd-cpp-api-core $<TARGET_OBJECTS:etcd-cpp-api-core-objects>)
-use_cxx11(etcd-cpp-api-core)
+use_cxx14(etcd-cpp-api-core)
 target_link_libraries(etcd-cpp-api-core PUBLIC
                       ${Boost_LIBRARIES}
                       ${PROTOBUF_LIBRARIES}
@@ -36,7 +36,7 @@ include_generated_protobuf_files(etcd-cpp-api-core)
 # add the client with asynchronus client
 add_library(etcd-cpp-api $<TARGET_OBJECTS:etcd-cpp-api-core-objects>
                          "${CMAKE_CURRENT_SOURCE_DIR}/Client.cpp")
-use_cxx11(etcd-cpp-api)
+use_cxx14(etcd-cpp-api)
 target_link_libraries(etcd-cpp-api PUBLIC
                       ${Boost_LIBRARIES}
                       ${CPPREST_LIB}  # n.b.: the asynchronous client requires pplx in cpprestsdk
@@ -56,4 +56,3 @@ else()
     install(TARGETS etcd-cpp-api-core etcd-cpp-api
             EXPORT etcd-targets)
 endif()
-

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(testfile ${TEST_FILES})
     else()
         add_executable(${test_name} EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR}/${testfile})
     endif()
-    use_cxx14(${test_name})
+    use_cxx(${test_name})
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
 
     target_include_directories(${test_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../proto/gen)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(testfile ${TEST_FILES})
     else()
         add_executable(${test_name} EXCLUDE_FROM_ALL ${CMAKE_CURRENT_SOURCE_DIR}/${testfile})
     endif()
-    use_cxx11(${test_name})
+    use_cxx14(${test_name})
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
 
     target_include_directories(${test_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../proto/gen)


### PR DESCRIPTION
Per abseil support policy, c++11 got dropped, thus updating `use_cxx11` to `use_cxx14` so that we can build from source with latest abseil

```
/opt/homebrew/include/absl/base/policy_checks.h:79:2: error: "C++ versions less than C++14 are not supported."
 ^
```

relates to https://github.com/Homebrew/homebrew-core/pull/121718

