### PR TITLE
Fixes the segmentation fault error in watcher

### DIFF
--- a/src/v3/AsyncLeaseAction.cpp
+++ b/src/v3/AsyncLeaseAction.cpp
@@ -187,7 +187,6 @@ void etcdv3::AsyncLeaseKeepAliveAction::CancelKeepAlive()
                 << context.debug_error_string() << std::endl;
     }
 
-    grpc::Status status;
     stream->Finish(&status, (void *)KEEPALIVE_FINISH);
     if (cq_.Next(&got_tag, &ok) && ok && got_tag == (void *)KEEPALIVE_FINISH) {
       // ok

--- a/src/v3/AsyncWatchAction.cpp
+++ b/src/v3/AsyncWatchAction.cpp
@@ -69,7 +69,6 @@ void etcdv3::AsyncWatchAction::waitForResponse()
     }
     if(got_tag == (void*)etcdv3::WATCH_WRITES_DONE)
     {
-      grpc::Status status;
       stream->Finish(&status, (void *)etcdv3::WATCH_FINISH);
       continue;
     }
@@ -84,7 +83,6 @@ void etcdv3::AsyncWatchAction::waitForResponse()
         // cancel on-the-fly calls, but don't shutdown the completion queue as there
         // are still a inflight call to finish
         context.TryCancel();
-        // cq_.Shutdown();
         continue;
       }
 
@@ -150,7 +148,6 @@ void etcdv3::AsyncWatchAction::waitForResponse(std::function<void(etcd::Response
     }
     if(got_tag == (void*)etcdv3::WATCH_WRITES_DONE)
     {
-      grpc::Status status;
       stream->Finish(&status, (void *)etcdv3::WATCH_FINISH);
       continue;
     }
@@ -171,7 +168,6 @@ void etcdv3::AsyncWatchAction::waitForResponse(std::function<void(etcd::Response
         // cancel on-the-fly calls, but don't shutdown the completion queue as there
         // are still a inflight call to finish
         context.TryCancel();
-        // cq_.Shutdown();
         continue;
       }
 


### PR DESCRIPTION
The `grpc::Status` should be globally lived as the `Finish()` operation is asynchoronous.