### PR TITLE
Fix error LNK1107 and undeclared identifier 'IPPROTO_TCP'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,20 +22,28 @@ use_cxx(etcd-cpp-api-core-objects)
 add_dependencies(etcd-cpp-api-core-objects protobuf_generates)
 include_generated_protobuf_files(etcd-cpp-api-core-objects)
 target_link_libraries(etcd-cpp-api-core-objects PUBLIC
-                      protobuf::libprotobuf
                       ${OPENSSL_LIBRARIES}
                       ${GRPC_LIBRARIES}
 )
+if(TARGET protobuf::libprotobuf)
+    target_link_libraries(etcd-cpp-api-core-objects PUBLIC protobuf::libprotobuf)
+else()
+    target_link_libraries(etcd-cpp-api-core-objects PUBLIC ${PROTOBUF_LIBRARIES})
+endif()
 
 if(BUILD_ETCD_CORE_ONLY)
     # add the core library, includes the sycnhronous client only
     add_library(etcd-cpp-api-core $<TARGET_OBJECTS:etcd-cpp-api-core-objects>)
     use_cxx(etcd-cpp-api-core)
     target_link_libraries(etcd-cpp-api-core PUBLIC
-                         protobuf::libprotobuf
-                         ${OPENSSL_LIBRARIES}
-                         ${GRPC_LIBRARIES}
+                          ${OPENSSL_LIBRARIES}
+                          ${GRPC_LIBRARIES}
     )
+    if(TARGET protobuf::libprotobuf)
+        target_link_libraries(etcd-cpp-api-core PUBLIC protobuf::libprotobuf)
+    else()
+        target_link_libraries(etcd-cpp-api-core PUBLIC ${PROTOBUF_LIBRARIES})
+    endif()
     include_generated_protobuf_files(etcd-cpp-api-core)
 else()
     # add the client with asynchronus client
@@ -44,10 +52,14 @@ else()
     use_cxx(etcd-cpp-api)
     target_link_libraries(etcd-cpp-api PUBLIC
                           ${CPPREST_LIB}  # n.b.: the asynchronous client requires pplx in cpprestsdk
-                          protobuf::libprotobuf
                           ${OPENSSL_LIBRARIES}
                           ${GRPC_LIBRARIES}
     )
+    if(TARGET protobuf::libprotobuf)
+        target_link_libraries(etcd-cpp-api PUBLIC protobuf::libprotobuf)
+    else()
+        target_link_libraries(etcd-cpp-api PUBLIC ${PROTOBUF_LIBRARIES})
+    endif()
     include_generated_protobuf_files(etcd-cpp-api)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ use_cxx(etcd-cpp-api-core-objects)
 add_dependencies(etcd-cpp-api-core-objects protobuf_generates)
 include_generated_protobuf_files(etcd-cpp-api-core-objects)
 target_link_libraries(etcd-cpp-api-core-objects PUBLIC
-                      ${PROTOBUF_LIBRARIES}
+                      protobuf::libprotobuf
                       ${OPENSSL_LIBRARIES}
                       ${GRPC_LIBRARIES}
 )
@@ -32,7 +32,7 @@ if(BUILD_ETCD_CORE_ONLY)
     add_library(etcd-cpp-api-core $<TARGET_OBJECTS:etcd-cpp-api-core-objects>)
     use_cxx(etcd-cpp-api-core)
     target_link_libraries(etcd-cpp-api-core PUBLIC
-                         ${PROTOBUF_LIBRARIES}
+                         protobuf::libprotobuf
                          ${OPENSSL_LIBRARIES}
                          ${GRPC_LIBRARIES}
     )
@@ -44,7 +44,7 @@ else()
     use_cxx(etcd-cpp-api)
     target_link_libraries(etcd-cpp-api PUBLIC
                           ${CPPREST_LIB}  # n.b.: the asynchronous client requires pplx in cpprestsdk
-                          ${PROTOBUF_LIBRARIES}
+                          protobuf::libprotobuf
                           ${OPENSSL_LIBRARIES}
                           ${GRPC_LIBRARIES}
     )

--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -4,6 +4,10 @@
 #define NOMINMAX
 #endif
 
+#ifdef __ANDROID__
+#include <netinet/in.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
When I [Update](https://github.com/microsoft/vcpkg/pull/32747) etcd-cpp-apiv3 version from 0.14.2 to 0.15.2, I get two build error:
````
fatal error LNK1107: invalid or corrupt file: cannot read at 0x330
````
````
error: use of undeclared identifier 'IPPROTO_TCP'
````

The first error was because the target `etcd-cpp-api-core-objects` linked the wrong `libprotobufd.dll` file instead of the .lib file, I used the usage provided by vcpkg to link the correct .lib file to fix this error.

Another error was because `IPPROTO_TCP` was missing declaration `"<netinet/in.h>"`, I added it to fix this error.