### PR TITLE
Fixes compiler errors

### DIFF
--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -72,7 +72,7 @@ etcd::KeepAlive::KeepAlive(
     std::function<void(std::exception_ptr)> const& handler, int ttl,
     int64_t lease_id, std::string const& target_name_override)
     : KeepAlive(SyncClient(address, ca, cert, privkey, target_name_override),
-                ttl, lease_id) {}
+                handler, ttl, lease_id) {}
 
 etcd::KeepAlive::KeepAlive(
     SyncClient const& client,

--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -147,7 +147,7 @@ const std::string strip_and_resolve_addresses(std::string const& address) {
   return "ipv4:///" + stripped_address;
 }
 
-const bool authenticate(std::shared_ptr<grpc::Channel> const& channel,
+bool authenticate(std::shared_ptr<grpc::Channel> const& channel,
                         std::string const& username,
                         std::string const& password,
                         std::string& token_or_message) {

--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -148,9 +148,8 @@ const std::string strip_and_resolve_addresses(std::string const& address) {
 }
 
 bool authenticate(std::shared_ptr<grpc::Channel> const& channel,
-                        std::string const& username,
-                        std::string const& password,
-                        std::string& token_or_message) {
+                  std::string const& username, std::string const& password,
+                  std::string& token_or_message) {
   // run a round of auth
   auto auth_stub = etcdserverpb::Auth::NewStub(channel);
   ClientContext context;


### PR DESCRIPTION
Hi, 

I was compiled it from the scratch with gcc (Debian 12.2.0-14) 12.2.0 with `-Wall` enabled and I got some error:

```
/opt/src/thirdparty/etcd-cpp-apiv3/src/KeepAlive.cpp:72:52: error: unused parameter 'handler' [-Werror=unused-parameter]
   72 |     std::function<void(std::exception_ptr)> const& handler, int ttl,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/opt/src/thirdparty/etcd-cpp-apiv3/src/SyncClient.cpp:150:1: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
  150 | const bool authenticate(std::shared_ptr<grpc::Channel> const& channel,  
```


The first one is an actual error that can lead to bugs if the ctor will be used. The handler passed to the ctor was omitted by mistake.