### PR TITLE
include stdint.h for int64_t types

### DIFF
--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -1,4 +1,5 @@
 #include <iomanip>
+#include <cstdint>
 
 #include "etcd/Value.hpp"
 #include "etcd/v3/KeyValue.hpp"


### PR DESCRIPTION
This is exposed when compiling for musl platforms where this header is not included indirectly.