### PR TITLE
doc:remove rm_if interface param: value in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,10 +534,10 @@ Values can be deleted with the `rm` method passing the key to be deleted as a pa
 should point to an existing value. There are conditional variations for deletion too.
 
 * `rm(std::string const& key)` unconditionally deletes the given key
-* `rm_if(key, value, old_value)` deletes an already existing value but only if the previous
+* `rm_if(key, old_value)` deletes an already existing value but only if the previous
   value equals with old_value. If the values does not match returns with "Compare failed" error
   (code `ERROR_COMPARE_FAILED`)
-* `rm_if(key, value, old_index)` deletes an already existing value but only if the index of
+* `rm_if(key, old_index)` deletes an already existing value but only if the index of
   the previous value equals with old_index. If the indices does not match returns with "Compare
   failed" error (code `ERROR_COMPARE_FAILED`)
 


### PR DESCRIPTION
remove  rm_if interface param: value in README.md

rm_if define as below:

```
  /**
   * Removes a single key but only if it has a specific value. Fails if the key
   * does not exists or the its value differs from the expected one.
   * @param key is the key to be deleted
   *
   * @return Returns etcdv3::ERROR_KEY_NOT_FOUND if the key does not exist.
   */
  pplx::task<Response> rm_if(std::string const& key,
                             std::string const& old_value);

  /**
   * Removes an existing key only if it has a specific modification index value.
   * Fails if the key does not exists or the modification index of it differs
   * from the expected one.
   * @param key is the key to be deleted
   * @param old_index is the expected index of the existing value
   *
   * @return Returns etcdv3::ERROR_KEY_NOT_FOUND if the key does not exist.
   */
  pplx::task<Response> rm_if(std::string const& key, int64_t old_index);
```