### PR TITLE
Replacing GPR_ASSERT with c assert

### DIFF
--- a/src/v3/Action.cpp
+++ b/src/v3/Action.cpp
@@ -2,6 +2,15 @@
 #include <grpc/support/log.h>
 #include <grpcpp/support/status.h>
 #include "etcd/v3/action_constants.hpp"
+#include <cstdlib>
+
+#ifndef GPR_ASSERT
+#define GPR_ASSERT(x)                                             \
+  if (!(x)) {                                                     \
+    fprintf(stderr, "%s:%d assert failed\n", __FILE__, __LINE__); \
+    abort();                                                      \
+}
+#endif
 
 etcdv3::Action::Action(etcdv3::ActionParameters const& params) {
   parameters = params;


### PR DESCRIPTION
Latest GRPC >= 2.66 has dropped GRPC_ASSERT macro [1]

[1] https://github.com/grpc/grpc/commit/0e23c2259da967a037e839e80cafd62bc6f9f68e

Upstream-Status: Pending