### PR TITLE
Add support for building etcd client with TLS and credentials

### DIFF
--- a/etcd/Client.hpp
+++ b/etcd/Client.hpp
@@ -251,6 +251,132 @@ class Client {
                          std::string const& privkey = "",
                          std::string const& target_name_override = "");
 
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param load_balancer is the load balance strategy, can be one of
+   * round_robin/pick_first/grpclb/xds.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   */
+  Client(std::string const& etcd_url,
+         std::string const& username,
+         std::string const& password,
+         std::string const& ca,
+         std::string const& cert,
+         std::string const& privkey,
+         std::string const& target_name_override,
+         std::string const& load_balancer = "round_robin",
+         int const auth_token_ttl = 300);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param arguments user provided grpc channel arguments.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   */
+  Client(std::string const& etcd_url,
+         std::string const& username,
+         std::string const& password,
+         std::string const& ca,
+         std::string const& cert,
+         std::string const& privkey,
+         std::string const& target_name_override,
+#if defined(WITH_GRPC_CHANNEL_CLASS)
+         grpc::ChannelArguments const& arguments,
+#else
+         grpc_impl::ChannelArguments const& arguments,
+#endif
+         int const auth_token_ttl);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param load_balancer is the load balance strategy, can be one of
+   * round_robin/pick_first/grpclb/xds.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   */
+  static Client* WithSSLUser(std::string const& etcd_url,
+                             std::string const& username,
+                             std::string const& password,
+                             std::string const& ca,
+                             std::string const& cert = "",
+                             std::string const& privkey = "",
+                             std::string const& target_name_override = "",
+                             std::string const& load_balancer = "round_robin",
+                             int const auth_token_ttl = 300);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   * @param arguments user provided grpc channel arguments.
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   */
+  static Client* WithSSLUser(std::string const& etcd_url,
+                             std::string const& username,
+                             std::string const& password,
+                             int const auth_token_ttl,
+#if defined(WITH_GRPC_CHANNEL_CLASS)
+                             grpc::ChannelArguments const& arguments,
+#else
+                             grpc_impl::ChannelArguments const& arguments,
+#endif
+                             std::string const& ca,
+                             std::string const& cert = "",
+                             std::string const& privkey = "",
+                             std::string const& target_name_override = "");
+
   ~Client();
 
   /**

--- a/etcd/SyncClient.hpp
+++ b/etcd/SyncClient.hpp
@@ -310,6 +310,132 @@ class SyncClient {
                              std::string const& privkey = "",
                              std::string const& target_name_override = "");
 
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param load_balancer is the load balance strategy, can be one of
+   * round_robin/pick_first/grpclb/xds.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   */
+  SyncClient(std::string const& etcd_url,
+             std::string const& username,
+             std::string const& password,
+             std::string const& ca,
+             std::string const& cert,
+             std::string const& privkey,
+             std::string const& target_name_override,
+             std::string const& load_balancer = "round_robin",
+             int const auth_token_ttl = 300);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param arguments user provided grpc channel arguments.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd.
+   */
+  SyncClient(std::string const& etcd_url,
+             std::string const& username,
+             std::string const& password,
+             std::string const& ca,
+             std::string const& cert,
+             std::string const& privkey,
+             std::string const& target_name_override,
+#if defined(WITH_GRPC_CHANNEL_CLASS)
+             grpc::ChannelArguments const& arguments,
+#else
+             grpc_impl::ChannelArguments const& arguments,
+#endif
+             int const auth_token_ttl);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   * @param load_balancer is the load balance strategy, can be one of
+   * round_robin/pick_first/grpclb/xds.
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd. Default value should be 300.
+   */
+  static SyncClient* WithSSLUser(std::string const& etcd_url,
+                                 std::string const& username,
+                                 std::string const& password,
+                                 std::string const& ca,
+                                 std::string const& cert = "",
+                                 std::string const& privkey = "",
+                                 std::string const& target_name_override = "",
+                                 std::string const& load_balancer = "round_robin",
+                                 int const auth_token_ttl = 300);
+
+  /**
+   * Constructs an etcd client object.
+   *
+   * @param etcd_url is the url of the etcd server to connect to, like
+   * "http://127.0.0.1:2379", or multiple url, separated by ',' or ';'.
+   * @param username username of etcd auth
+   * @param password password of etcd auth
+   * @param auth_token_ttl TTL seconds for auth token, see also
+   * `--auth-token-ttl` flags of etcd. Default value should be 300.
+   * @param arguments user provided grpc channel arguments.
+   * @param ca      root CA file for SSL/TLS connection.
+   * @param cert    cert chain file for SSL/TLS authentication, could be empty
+   * string.
+   * @param privkey private key file for SSL/TLS authentication, could be empty
+   * string.
+   * @param target_name_override Override the target host name if you want to
+   * pass multiple address for load balancing with SSL, and there's no DNS. The
+   * @target_name_override@ must exist in the SANS of your SSL certificate.
+   */
+  static SyncClient* WithSSLUser(std::string const& etcd_url,
+                                 std::string const& username,
+                                 std::string const& password,
+                                 int const auth_token_ttl,
+#if defined(WITH_GRPC_CHANNEL_CLASS)
+                                 grpc::ChannelArguments const& arguments,
+#else
+                                 grpc_impl::ChannelArguments const& arguments,
+#endif
+                                 std::string const& ca,
+                                 std::string const& cert = "",
+                                 std::string const& privkey = "",
+                                 std::string const& target_name_override = "");
+
   ~SyncClient();
 
   /**

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -145,6 +145,88 @@ etcd::Client* etcd::Client::WithSSL(std::string const& etcd_url,
                           arguments);
 }
 
+etcd::Client::Client(std::string const& address,
+                     std::string const& username,
+                     std::string const& password,
+                     std::string const& ca,
+                     std::string const& cert,
+                     std::string const& privkey,
+                     std::string const& target_name_override,
+                     std::string const& load_balancer,
+                     int const auth_token_ttl) {
+  this->own_client = true;
+  this->client = new SyncClient(address,
+                                username,
+                                password,
+                                ca,
+                                cert,
+                                privkey,
+                                target_name_override,
+                                load_balancer,
+                                auth_token_ttl);
+}
+
+etcd::Client::Client(std::string const& address,
+                     std::string const& username,
+                     std::string const& password,
+                     std::string const& ca,
+                     std::string const& cert,
+                     std::string const& privkey,
+                     std::string const& target_name_override,
+                     grpc::ChannelArguments const& arguments,
+                     int const auth_token_ttl) {
+  this->own_client = true;
+  this->client = new SyncClient(address,
+                                username,
+                                password,
+                                ca,
+                                cert,
+                                privkey,
+                                target_name_override,
+                                arguments,
+                                auth_token_ttl);
+}
+
+etcd::Client* etcd::Client::WithSSLUser(std::string const& etcd_url,
+                                        std::string const& username,
+                                        std::string const& password,
+                                        std::string const& ca,
+                                        std::string const& cert,
+                                        std::string const& privkey,
+                                        std::string const& target_name_override,
+                                        std::string const& load_balancer,
+                                        int const auth_token_ttl) {
+  return new etcd::Client(etcd_url,
+                          username,
+                          password,
+                          ca,
+                          cert,
+                          privkey,
+                          target_name_override,
+                          load_balancer,
+                          auth_token_ttl);
+}
+
+etcd::Client* etcd::Client::WithSSLUser(std::string const& etcd_url,
+                                        std::string const& username,
+                                        std::string const& password,
+                                        int const auth_token_ttl,
+                                        grpc::ChannelArguments const& arguments,
+                                        std::string const& ca,
+                                        std::string const& cert,
+                                        std::string const& privkey,
+                                        std::string const& target_name_override) {
+  return new etcd::Client(etcd_url,
+                          username,
+                          password,
+                          ca,
+                          cert,
+                          privkey,
+                          target_name_override,
+                          arguments,
+                          auth_token_ttl);
+}
+
 etcd::Client::~Client() {
   if (this->own_client) {
     delete this->client;

--- a/src/SyncClient.cpp
+++ b/src/SyncClient.cpp
@@ -570,6 +570,115 @@ etcd::SyncClient* etcd::SyncClient::WithSSL(
                               arguments);
 }
 
+etcd::SyncClient::SyncClient(std::string const& address,
+                             std::string const& username,
+                             std::string const& password,
+                             std::string const& ca,
+                             std::string const& cert,
+                             std::string const& privkey,
+                             std::string const& target_name_override,
+                             std::string const& load_balancer,
+                             int const auth_token_ttl) {
+  // create channels
+  grpc::ChannelArguments grpc_args;
+  grpc_args.SetMaxSendMessageSize(std::numeric_limits<int>::max());
+  grpc_args.SetMaxReceiveMessageSize(std::numeric_limits<int>::max());
+  std::shared_ptr<grpc::ChannelCredentials> creds = grpc::SslCredentials(
+      etcd::detail::make_ssl_credentials(ca, cert, privkey));
+  grpc_args.SetLoadBalancingPolicyName(load_balancer);
+  if (!target_name_override.empty()) {
+    grpc_args.SetString(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG,
+                        target_name_override);
+  }
+  this->channel = etcd::detail::create_grpc_channel(address, creds, grpc_args);
+
+  // auth
+  this->token_authenticator.reset(new TokenAuthenticator(
+      this->channel, username, password, auth_token_ttl));
+
+  // setup stubs
+  stubs.reset(new EtcdServerStubs{});
+  stubs->kvServiceStub = KV::NewStub(this->channel);
+  stubs->watchServiceStub = Watch::NewStub(this->channel);
+  stubs->leaseServiceStub = Lease::NewStub(this->channel);
+  stubs->lockServiceStub = Lock::NewStub(this->channel);
+  stubs->electionServiceStub = Election::NewStub(this->channel);
+}
+
+etcd::SyncClient::SyncClient(std::string const& address,
+                             std::string const& username,
+                             std::string const& password,
+                             std::string const& ca,
+                             std::string const& cert,
+                             std::string const& privkey,
+                             std::string const& target_name_override,
+                             grpc::ChannelArguments const& arguments,
+                             int const auth_token_ttl) {
+  // create channels
+  grpc::ChannelArguments grpc_args = arguments;
+  grpc_args.SetMaxSendMessageSize(std::numeric_limits<int>::max());
+  grpc_args.SetMaxReceiveMessageSize(std::numeric_limits<int>::max());
+  std::shared_ptr<grpc::ChannelCredentials> creds = grpc::SslCredentials(
+      etcd::detail::make_ssl_credentials(ca, cert, privkey));
+  if (!target_name_override.empty()) {
+    grpc_args.SetString(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG,
+                        target_name_override);
+  }
+  this->channel = etcd::detail::create_grpc_channel(address, creds, grpc_args);
+
+  // auth
+  this->token_authenticator.reset(new TokenAuthenticator(
+      this->channel, username, password, auth_token_ttl));
+
+  // setup stubs
+  stubs.reset(new EtcdServerStubs{});
+  stubs->kvServiceStub = KV::NewStub(this->channel);
+  stubs->watchServiceStub = Watch::NewStub(this->channel);
+  stubs->leaseServiceStub = Lease::NewStub(this->channel);
+  stubs->lockServiceStub = Lock::NewStub(this->channel);
+  stubs->electionServiceStub = Election::NewStub(this->channel);
+}
+
+etcd::SyncClient* etcd::SyncClient::WithSSLUser(std::string const& etcd_url,
+                                                std::string const& username,
+                                                std::string const& password,
+                                                std::string const& ca,
+                                                std::string const& cert,
+                                                std::string const& privkey,
+                                                std::string const& target_name_override,
+                                                std::string const& load_balancer,
+                                                int const auth_token_ttl) {
+  return new etcd::SyncClient(etcd_url,
+                              username,
+                              password,
+                              ca,
+                              cert,
+                              privkey,
+                              target_name_override,
+                              load_balancer,
+                              auth_token_ttl);
+}
+
+etcd::SyncClient* etcd::SyncClient::WithSSLUser(std::string const& etcd_url,
+                                                std::string const& username,
+                                                std::string const& password,
+                                                int const auth_token_ttl,
+                                                grpc::ChannelArguments const& arguments,
+                                                std::string const& ca,
+                                                std::string const& cert,
+                                                std::string const& privkey,
+                                                std::string const& target_name_override) {
+  return new etcd::SyncClient(etcd_url,
+                              username,
+                              password,
+                              ca,
+                              cert,
+                              privkey,
+                              target_name_override,
+                              arguments,
+                              auth_token_ttl);
+}
+
 etcd::SyncClient::~SyncClient() {
   stubs.reset();
   channel.reset();


### PR DESCRIPTION
This pull request introduces the ability to create an etcd client using TLS configuration and user credentials.

- Added TLS support (certificates, keys, CA).
- Enabled authentication with username and password.
- Ensure secure connection to etcd clusters requiring authentication.

This enhancement allows more secure and flexible etcd client usage in environments where encryption and authentication are required.