### PR TITLE
Align keepalive refresh interval with etcd Go client to improve stability

### DIFF
--- a/src/KeepAlive.cpp
+++ b/src/KeepAlive.cpp
@@ -204,7 +204,7 @@ std::string etcd::KeepAlive::refresh() {
       return std::string{};
     }
     // minimal resolution: 1 second
-    int keepalive_ttl = std::max(ttl - 1, 1);
+    int keepalive_ttl = std::max(ttl / 3, 1);
     {
       std::unique_lock<std::mutex> lock(mutex_for_refresh_);
       if (cv_for_refresh_.wait_for(lock, std::chrono::seconds(keepalive_ttl)) ==


### PR DESCRIPTION
Previously, the `etcd-cpp-api-v3` client library used a keepalive refresh interval of `TTL - 1`, which could be unstable in the presence of temporary network issues. In this PR, I’ve updated it to `TTL / 3`, aligning it with the etcd Go client implementation (see [details here](https://github.com/etcd-io/etcd/blob/main/client/v3/lease.go#L542)). This change makes keepalive expiration less likely due to transient network problems.